### PR TITLE
ci: release workflow — 7-platform binary build + checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,11 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: latest
+          bun-version: 1.3.11
 
       - name: Install Linux vault tools
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,14 +14,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Run tests
+        run: bun test
 
       - name: Build binaries
         run: |
@@ -60,7 +63,7 @@ jobs:
         run: sha256sum see-crets-* > checksums.txt
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: |
             dist/see-crets-macos-arm64


### PR DESCRIPTION
## Summary

Closes #21

Adds a GitHub Actions release workflow that builds 7 self-contained cross-compiled binaries and publishes them as GitHub Release assets whenever a `v*.*.*` tag is pushed.

## Changes

- `.github/workflows/release.yml` — new release workflow

**What the workflow does:**

1. Triggers on `push` to tags matching `v*.*.*`
2. Runs on a single `ubuntu-latest` runner — Bun's `--target` flag handles all cross-compilation natively, no matrix needed
3. Builds all 7 binaries:
   - `see-crets-macos-arm64` (`--target=bun-darwin-arm64`)
   - `see-crets-macos-x64` (`--target=bun-darwin-x64`)
   - `see-crets-linux-x64` (`--target=bun-linux-x64`)
   - `see-crets-linux-x64-musl` (`--target=bun-linux-x64-musl`)
   - `see-crets-linux-arm64` (`--target=bun-linux-arm64`)
   - `see-crets-linux-arm64-musl` (`--target=bun-linux-arm64-musl`)
   - `see-crets-windows-x64.exe` (`--target=bun-windows-x64`)
4. Generates `checksums.txt` via `sha256sum see-crets-*` (standard `<hash>  <filename>` format)
5. Uploads all 8 files as Release assets via `softprops/action-gh-release@v2`

**Design decisions:**
- Sequential builds on one runner (simpler than a matrix) — Bun cross-compiles without needing per-platform runners
- Bun version pinned to `1.3.11` (sourced from `@types/bun@1.3.11` in `bun.lock`)
- musl targets use native Bun cross-compilation (`bun-linux-x64-musl`, `bun-linux-arm64-musl`) — no Alpine container needed

## Testing

- [x] `bun test` passes (149 pass; 14 pre-existing failures in `opencode.test.ts` due to missing `@opencode-ai/plugin` dev dependency — unrelated to this change)
- [ ] `bun run lint` passes
- [x] `bun run build` succeeds
- [x] Workflow YAML is syntactically valid

## Security checklist

- [x] N/A — this change does not touch security-sensitive code

## Notes for reviewers

**Open question on musl targets**: Bun 1.x natively supports `bun-linux-x64-musl` and `bun-linux-arm64-musl` as cross-compilation targets (confirmed from Bun source `compile_target.zig`). Bun downloads the musl-linked binary during compilation. However, this is untested until a real tag push — if the targets fail at runtime, the fallback is to add an Alpine-based job for musl builds.