### PR TITLE
fix: install.ps1 PS7+ compat and error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,20 @@ jobs:
       - name: Build binary
         run: bun run build
 
-      - name: Validate install.ps1 syntax (Windows only)
+      - name: Validate install.ps1 syntax (PS 5.1)
         if: matrix.os == 'windows-latest'
         shell: powershell
         run: |
           [scriptblock]::Create((Get-Content '.\install.ps1' -Raw)) | Out-Null
-          Write-Host "install.ps1 syntax OK"
+          Write-Host "install.ps1 syntax OK (PS 5.1)"
+
+      # Full integration test requires published release assets — deferred until first v*.*.* tag
+      - name: Validate install.ps1 syntax (PS 7+)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          [scriptblock]::Create((Get-Content '.\install.ps1' -Raw)) | Out-Null
+          Write-Host "install.ps1 syntax OK (PS 7+)"
 
   install-sh:
     name: install.sh (shellcheck)

--- a/install.ps1
+++ b/install.ps1
@@ -42,12 +42,11 @@ function Remove-TmpDir {
 
 function Exit-Fatal {
     param(
-        [string]$Message,
-        [int]$Code = 1
+        [string]$Message
     )
     Write-Host "ERROR: $Message" -ForegroundColor Red
     Remove-TmpDir
-    exit $Code
+    throw $Message
 }
 
 # ─── Architecture detection ──────────────────────────────────────────────────
@@ -86,10 +85,16 @@ if (-not [string]::IsNullOrWhiteSpace($env:VERSION)) {
 } else {
     Write-Host "Fetching latest release version..."
     try {
-        $releaseInfo = Invoke-RestMethod `
-            -Uri 'https://api.github.com/repos/yldgio/see-crets/releases/latest' `
-            -UseBasicParsing `
-            -ErrorAction Stop
+        if ($PSVersionTable.PSVersion.Major -lt 6) {
+            $releaseInfo = Invoke-RestMethod `
+                -Uri 'https://api.github.com/repos/yldgio/see-crets/releases/latest' `
+                -UseBasicParsing `
+                -ErrorAction Stop
+        } else {
+            $releaseInfo = Invoke-RestMethod `
+                -Uri 'https://api.github.com/repos/yldgio/see-crets/releases/latest' `
+                -ErrorAction Stop
+        }
         $Version = ([string]$releaseInfo.tag_name).TrimStart('v')
         if ([string]::IsNullOrWhiteSpace($Version)) {
             Exit-Fatal "GitHub API returned an empty or invalid version tag. Use `$env:VERSION` to pin a version."
@@ -125,22 +130,36 @@ $checksumPath = Join-Path $Script:_tmpDir 'checksums.txt'
 
 Write-Host "Downloading $assetName..."
 try {
-    Invoke-WebRequest `
-        -Uri     "$baseUrl/$assetName" `
-        -OutFile $binaryPath `
-        -UseBasicParsing `
-        -ErrorAction Stop
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        Invoke-WebRequest `
+            -Uri     "$baseUrl/$assetName" `
+            -OutFile $binaryPath `
+            -UseBasicParsing `
+            -ErrorAction Stop
+    } else {
+        Invoke-WebRequest `
+            -Uri     "$baseUrl/$assetName" `
+            -OutFile $binaryPath `
+            -ErrorAction Stop
+    }
 } catch {
     Exit-Fatal "Download failed for '$assetName': $_"
 }
 
 Write-Host "Downloading checksums.txt..."
 try {
-    Invoke-WebRequest `
-        -Uri     "$baseUrl/checksums.txt" `
-        -OutFile $checksumPath `
-        -UseBasicParsing `
-        -ErrorAction Stop
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+        Invoke-WebRequest `
+            -Uri     "$baseUrl/checksums.txt" `
+            -OutFile $checksumPath `
+            -UseBasicParsing `
+            -ErrorAction Stop
+    } else {
+        Invoke-WebRequest `
+            -Uri     "$baseUrl/checksums.txt" `
+            -OutFile $checksumPath `
+            -ErrorAction Stop
+    }
 } catch {
     Exit-Fatal "Download failed for 'checksums.txt': $_"
 }
@@ -187,13 +206,16 @@ if (-not [string]::IsNullOrWhiteSpace($Prefix)) {
     $installDir = Join-Path $env:USERPROFILE '.see-crets\bin'
 }
 
-Write-Host "Installing to $installDir ..."
-New-Item -ItemType Directory -Path $installDir -Force | Out-Null
-
-$installPath = Join-Path $installDir 'see-crets.exe'
-Copy-Item -Path $binaryPath -Destination $installPath -Force -ErrorAction Stop
-
-Remove-TmpDir
+try {
+    Write-Host "Installing to $installDir ..."
+    New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+    $installPath = Join-Path $installDir 'see-crets.exe'
+    Copy-Item -Path $binaryPath -Destination $installPath -Force -ErrorAction Stop
+} catch {
+    Exit-Fatal "Failed to install to '$installDir': $($_.Exception.Message)"
+} finally {
+    Remove-TmpDir
+}
 
 Write-Host "Installed: $installPath"
 


### PR DESCRIPTION
Addresses unresolved Copilot review comments from #35 (already merged).

Fixes:
- Gate `-UseBasicParsing` to PS 5.1 for `Invoke-RestMethod` and `Invoke-WebRequest` — PS7+ throws `ParameterBindingException` on this unknown parameter
- `Exit-Fatal` uses `throw` instead of `exit` to avoid closing the interactive PowerShell host when run as `.\install.ps1 -Prefix ...`; `Remove-TmpDir` is retained before the throw so temp dir cleanup still runs on all fatal paths (download, checksum, version-fetch failures)
- Install section (`New-Item` + `Copy-Item`) wrapped in `try/catch/finally` — temp dir is always cleaned up even when install fails mid-way
- CI: add PS 7+ syntax validation step (`shell: pwsh`) alongside the existing PS 5.1 step (`shell: powershell`); add comment explaining why full integration test is deferred until first `v*.*.*` tag

Related: #24 #35
